### PR TITLE
Switched over to using 1.19.4 instead of 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /rpkmcserver-build
 WORKDIR /rpkmcserver-build
 RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 RUN git config --global --unset core.autocrlf || :
-RUN java -jar BuildTools.jar --rev 1.20.4
+RUN java -jar BuildTools.jar --rev 1.19.4
 
 # Download & install community plugins -----------------------------
 WORKDIR /jars

--- a/post-create.sh
+++ b/post-create.sh
@@ -2,7 +2,7 @@ echo "Running 'post-create.sh' script..."
 if [ -z "$(ls -A /rpkmcserver)" ]; then
     echo "Setting up server..."
     # Copy server JAR
-    cp /rpkmcserver-build/spigot-1.20.4.jar /rpkmcserver/spigot-1.20.4.jar
+    cp /rpkmcserver-build/spigot-1.19.4.jar /rpkmcserver/spigot-1.19.4.jar
 
     # Create plugins directory
     mkdir /rpkmcserver/plugins
@@ -16,4 +16,4 @@ else
     echo "Server is already set up."
 fi
 
-java -jar /rpkmcserver/spigot-1.20.4.jar
+java -jar /rpkmcserver/spigot-1.19.4.jar


### PR DESCRIPTION
## Problem
The version of RPKit we are using supports 1.19.4, not 1.20.4.

## Solution
We are now using Spigot 1.19.4

## Testing
This was tested locally.