### PR TITLE
Specify Operators & Plugin Overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,9 @@ RUN wget https://github.com/RP-Kit/RPKit/releases/download/v2.4.2/rpk-warp-lib-b
 COPY ./post-create.sh /post-create.sh
 RUN chmod +x /post-create.sh
 
+# Copy config directory
+COPY ./config /config
+
 # Run server
 WORKDIR /rpkmcserver
 EXPOSE 25565

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ An infrastructure-as-code Minecraft server for the [RPKit](https://github.com/RP
 2. You will now be in the server's filesystem. You can modify files as you wish.
 3. When you are done, run `exit` to exit the container.
 4. Run `docker-compose restart` to restart the server with your changes.
+
+## Troubleshooting
+### /post-create.sh: 25: Syntax error: end of file unexpected (expecting "then")
+This occurs when the EOF sequence for the `post-create.sh` script is CRLF. In order for the script to function, it needs to be LF.

--- a/config/ops.json
+++ b/config/ops.json
@@ -1,0 +1,8 @@
+[
+  {
+    "uuid": "0a9fa342-3139-49d7-8acb-fcf4d9c1f0ef",
+    "name": "DanTheTechMan",
+    "level": 4,
+    "bypassesPlayerLimit": false
+  }
+]

--- a/post-create.sh
+++ b/post-create.sh
@@ -10,10 +10,16 @@ if [ -z "$(ls -A /rpkmcserver)" ]; then
     # Copy JARs
     cp /jars/*.jar /rpkmcserver/plugins
 
+    # Copy config files
+    cp /config/ops.json /rpkmcserver
+
     # Accept EULA
     cd /rpkmcserver && echo "eula=true" > eula.txt
 else
     echo "Server is already set up."
 fi
+
+echo "Copying file overrides..."
+cp /deposit-box/plugin-overrides/*.jar /rpkmcserver/plugins
 
 java -jar /rpkmcserver/spigot-1.19.4.jar


### PR DESCRIPTION
## Problem
There is a need to specify operators and plugins that should override those defined in the Dockerfile for testing purposes.

## Solution
These changes make it possible to override the `op.json` file and designate a number of JAR files to be copied into the plugins directory at startup.